### PR TITLE
Add check extra798 to iso27001

### DIFF
--- a/groups/group18_iso27001
+++ b/groups/group18_iso27001
@@ -15,7 +15,7 @@ GROUP_ID[18]='iso27001'
 GROUP_NUMBER[18]='18.0'
 GROUP_TITLE[18]='ISO 27001:2013 Readiness - ONLY AS REFERENCE - [iso27001] *****'
 GROUP_RUN_BY_DEFAULT[18]='N' # run it when execute_all is called
-GROUP_CHECKS[18]='check11,check110,check111,check112,check113,check116,check12,check122,check13,check14,check15,check16,check17,check18,check19,check21,check23,check24,check25,check26,check29,check31,check310,check311,check312,check313,check314,check32,check33,check34,check35,check36,check37,check38,check39,check41,check42,check43,extra711,extra72,extra723,extra731,extra735,extra76,extra78,extra792'
+GROUP_CHECKS[18]='check11,check110,check111,check112,check113,check116,check12,check122,check13,check14,check15,check16,check17,check18,check19,check21,check23,check24,check25,check26,check29,check31,check310,check311,check312,check313,check314,check32,check33,check34,check35,check36,check37,check38,check39,check41,check42,check43,extra711,extra72,extra723,extra731,extra735,extra76,extra78,extra792,extra798'
 
 # #	Category	Objective ID	Objective Name	Prowler check ID	Check Summary
 # 1	A.10 Cryptography	A.10.1	Cryptographic Controls	extra735	Setup Encryption at rest for RDS instances
@@ -59,6 +59,7 @@ GROUP_CHECKS[18]='check11,check110,check111,check112,check113,check116,check12,c
 # 39	A.13 Communications Security	A.13.1	Network Security Management	extra711	Ensure Redshift clusters do not have a public endpoint
 # 40	A.13 Communications Security	A.13.1	Network Security Management	extra723	Ensure RDS snapshots are not publicly accessible
 # 41	A.13 Communications Security	A.13.1	Network Security Management	extra78	Ensure RDS instances are not accessible to the world.
+# 82	A.13 Communications Security	A.13.1	Network Security Management	extra798	Ensure Lambda Functions are not publicly accessible
 # 42	A.9 Access Control	A.9.2	User Access Management	check122	Ensure IAM policies that allow full "*:*" administrative privileges are not created.
 # 43	A.9 Access Control	A.9.2	User Access Management	check111	Ensure IAM password policy expires passwords within 90 days or less
 # 44	A.9 Access Control	A.9.2	User Access Management	check110	Ensure IAM password policy prevents password reuse


### PR DESCRIPTION
Added check extra798 to iso27001 group. This maps as below:
| Category | Objective ID | Objective name | Prowler Check ID | Check Summary |
|-|-|-|-|-|
| A.13 Communications Security | A.13.1 | Network Security Management | extra798 | Ensure Lambda functions are not publicly accessible |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
